### PR TITLE
[codex] sync knowledge docs and source comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         # `jq` + homebrew's bash 5.x are required for several tests that
         # source functions via process substitution and use jq in
         # assertions. The stock /usr/bin/bash 3.2 + no-jq macos-latest
-        # runner fails 7/118 without these.
+        # runner has historically failed without these dependencies.
         run: |
           brew update >/dev/null
           brew install bats-core jq bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,15 @@
 # CLAUDE.md
 
-<!-- Last updated: 2026-04-20 | Audit cycle: 2026-04-20 (follow-on cycle — smart-mode / self-update / hooks) -->
+<!-- Last updated: 2026-04-20 | Audit cycle: 2026-04-20 (docs/comment sync after PR #5) -->
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Knowledge authority
+
+- `README.md` is the public user/contributor source of truth: install path, CLI behavior, flags, test commands, release workflow, and troubleshooting.
+- `CLAUDE.md` is the maintainer/agent source of truth: architecture, invariants, conventions, audit history, known risks, and implementation navigation.
+- `CONTRIBUTING.md`, `SECURITY.md`, and `PUBLIC_RELEASE_CHECKLIST.md` are domain-specific satellites. Keep them consistent with `README.md` and reference `CLAUDE.md` for implementation details instead of duplicating architecture.
+- `.github/workflows/ci.yml` and `.pre-commit-config.yaml` define the enforced verification pipeline. If docs and these files disagree about checks, update the docs to match the configs.
 
 ## Repository layout
 
@@ -95,11 +102,12 @@ Regression tests: `tests/hooks.bats`, `tests/hook-command-runtime.bats` (F-03 ru
 
 ## Smart-watch semantics
 
-`smart_watch_loop` fires sleep only when **all three** conditions hold:
+`smart_watch_loop` fires sleep only when the enforced hook-state conditions hold:
 
 1. **Proof-of-life** — at least one busy marker has been observed since watch start OR one already exists at entry (F-01 cold-start guard — prevents premature-sleep when hooks aren't loaded in the running session yet).
 2. **Continuous idle** — busy count has been 0 for `SMART_IDLE_SECONDS` uninterrupted.
-3. ~~Live-process absence~~ — documented as belt-and-suspenders in the function header but not currently enforced in the loop body; `--smart` relies on hook-based signals only. If the user's Claude session pre-dates hook install (hooks not yet loaded), the loop warns via the spinner text ("Waiting for a Claude prompt…") and stays in cold mode indefinitely.
+
+`--smart` relies on hook-based signals only; it does not enforce a separate live-process absence guard. If the user's Claude session pre-dates hook install (hooks not yet loaded), the loop warns via the spinner text ("Waiting for a Claude prompt…") and stays in cold mode indefinitely.
 
 Default-mode selection (lines ~1762–1781): if the user passes no explicit watch flag, `goodnight` picks `--smart` when `hooks_installed` returns true, otherwise `--watch-pid`. Early-exit modes (`--install-hooks`, `--uninstall-hooks`, `--preflight`, `--list`, `--log-summary`, `--sleep-now`) bypass the selection entirely.
 
@@ -184,7 +192,7 @@ Linear top-to-bottom flow with labeled section banners (`# ── Section ──
 1. **macOS guard + TTY/Bash-version detection** — sets `USE_BUILTIN_SLEEP` (Bash ≥ 4 FIFO trick to avoid forking `sleep`), color toggles, and TTY flags that downstream output branches on. Captures `SAC_ORIGINAL_ARGS` up-front for the self-update re-exec path (F-05).
 2. **Colours + config defaults** — flag-state booleans, paths, TTL values.
 3. **Helpers** — `print_*` helpers, `elapsed_label`, `play_sound`, `as_escape` / `json_escape`, `notify_macos`, `log_event` (warn-once on write failure), `micro_sleep` (FIFO builtin fast-path).
-4. **gum / glow integration** — optional polish layer. `have_gum` / `have_glow` detection gates TUI rendering (panels, confirms, menus, spinners). Over SSH: gum defaults off because mobile SSH clients (Termius/Blink) mishandle `/dev/tty` and arrow keys. `SAC_NO_GUM=1` forces fallback; `SAC_FORCE_GUM=1` re-enables over SSH; `SAC_NO_GLOW=1` disables markdown rendering.
+4. **gum / glow integration** — optional polish layer. `have_gum` / `have_glow` detection gates TUI rendering (panels, confirms, menus, spinners, markdown help/log summary rendering). Over SSH: gum defaults off because mobile SSH clients (Termius/Blink) mishandle `/dev/tty` and arrow keys. `SAC_NO_GUM=1` forces fallback; `SAC_FORCE_GUM=1` re-enables over SSH; `SAC_NO_GLOW=1` disables markdown rendering. Confirmation prompts fail closed when stdin is not a TTY.
 5. **Claude process detection** (`find_claude_processes`) — two-tier: a "tight" pass using `pgrep -x claude` / `pgrep -f claude-code`, falling back to a broad `pgrep -fi claude` filtered by `EXCLUDE_PATTERN` to weed out Electron apps (Claude.app, Cursor, Windsurf, chrome-native-host, `anthropic-tools`, etc.). When adding a new false-positive, update `EXCLUDE_PATTERN`.
 6. **Pre-flight scan** (`scan_assertions`, `preflight_scan`, `render_preflight*`) — inventories caffeinate processes, `pmset -g assertions`, clamshell/lid state, battery, user sessions, then emits a verdict. Gated by `--no-preflight`, restricted by `--brief`, machine-readable via `--json`. See "Preflight fail-closed contract" above.
 7. **Blocker classification** (`classify_blocker`, `prompt_and_handle_blockers`, `print_post_watch_blockers`) — groups assertions into severity buckets and drives the interactive terminate/skip/abort menu when blockers are present.
@@ -213,10 +221,15 @@ When modifying behavior, identify which section owns the concern; most flags tou
 - Bash, `set -uo pipefail` (intentionally no `-e` — the script relies on non-zero exits from `pgrep` being non-fatal).
 - All user-facing output goes through `print_header` / `print_step` / `print_ok` / `print_warn` / `print_error` / `print_done`. Don't emit raw `echo` for status lines — these helpers handle TTY/non-TTY color stripping.
 - Styled UI (confirms, menus, panels, spinners) goes through `ui_confirm` / `ui_choose` / `ui_panel` / `ui_spin` so gum / hand-drawn fallback selection happens in one place.
+- Markdown help and log-summary output goes through `ui_markdown` so `glow` remains optional and non-TTY output stays plain.
 - Integer validation uses `is_integer` / `is_positive_integer`; reuse rather than inlining regex.
 - `printf` format strings used with dynamic data must be **static** (every dynamic value passes through `%s`) — stray `%` in battery percents, cmd names, etc. would otherwise corrupt the format. Search "Static format" in the source for the safety pattern.
 - `--json` output is consumed by automation; any new preflight field must be added to the JSON emitter **and** the human-readable renderer **and** the JSON-shape assertions in `tests/preflight-fail-closed.bats`.
 - `log_event` writes to `$LOG_FILE` only when `--log` is set. It warns to stderr **once per session** on first write failure (brace-grouped `{ echo ...; } 2>/dev/null` so bash's own redirection error is also suppressed). Subsequent failures stay silent to avoid spamming the watch loop. Event names are stable — `--log-summary` groups on them.
+
+### Commenting standard
+
+This is a Bash project, so production comments use `#` comments rather than JSDoc/TSDoc. Keep comments close to the function or control-flow block they explain. File headers should state the script's responsibility and consumers. Function comments should document contracts, failure behavior, side effects, and non-obvious safety constraints; do not add comments that merely restate a function name or a simple assignment. If `sleep-after-claude` comments change, mirror the same comment-only update into the embedded payload in `install-sleep-after-claude.sh` and run `bash scripts/check-parity.sh`.
 
 ### Formatting / linting
 
@@ -244,24 +257,20 @@ For editor experience, `bash-language-server` gives real-time shellcheck diagnos
 
 ## Audit cycle history
 
-### 2026-04-20 (follow-on cycle)
+### 2026-04-20 (PR #4 / PR #5 safety follow-up)
 
-Second audit → remediation → test expansion → docs sync cycle, scoped to the features added between 2026-04-19 and 2026-04-20 (`--smart` mode, `--sleep-now`, self-update, hook integration, jq auto-install, power gate, `gum`/`glow` polish).
+Latest audit → remediation → test expansion cycle on `main`, focused on smart-mode correctness, hook failure safety, dry-run side effects, and terminal UI behavior.
 
-- **Remediation (12 findings across 6 commits):**
-  - **F-01** (`8b9ed7a`) — `smart_watch_loop` cold-start: require proof-of-life (busy marker) before arming the idle countdown.
-  - **F-02** (`ad64164`) — SHA-256 verification for auto-downloaded `jq` binary; per-arch expected hashes, override via `SAC_JQ_SHA256`.
-  - **F-03** (`79d8e4f`) — lazy-expand `$HOME` in Claude hook commands so they survive home-dir moves and differ-context invocations.
-  - **F-04** (`79d8e4f`) — harden path quoting in hook commands against `$` / whitespace / metachars in custom `BUSY_DIR` values.
-  - **F-05** (`6e9871f`) — self-update re-exec: `exec` into the freshly-installed script preserving `SAC_ORIGINAL_ARGS`; set `SAC_SKIP_UPDATE_CHECK=1` in child env.
-  - **F-06** (`6e9871f`) — hook-install opt-out (`SAC_SKIP_HOOK_INSTALL=1`); explicit announcement before touching `~/.claude/settings.json`.
-  - **F-07** (`b63e632`) — mutual-exclusion lock (`~/.local/state/goodnight/lock` via atomic `mkdir`) to prevent concurrent watches racing on caffeinate + pmset.
-  - **F-08** (`8b9ed7a`) — stale-marker reaper threshold loosened to 24h so long-running Claude tasks aren't reaped mid-work; override via `SAC_STALE_MARKER_MINUTES`.
-  - **F-09** (`ad64164`) — probe common `jq` paths (`~/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`) before reaching for the network.
-  - **F-11** (`b3b8981`) — bound installer stdin drain with `gtimeout` / `timeout` / background-watchdog fallback.
-  - **F-12** (`b3b8981`) — removed double-cleanup: `on_interrupt` no longer calls `cleanup_fd_and_tmp` directly; EXIT trap owns cleanup.
-- **Test expansion (`df6138d` + the fix commits):** runtime tests added for F-01, F-02, F-03, F-04, F-07 plus unit/semantic coverage across all remediated areas. Totals are retrievable via `bats tests/ --count`.
-- **Docs (this commit):** CLAUDE.md + README.md rewritten to reflect the post-remediation state, including new subsystems (hooks, self-update, power gate, concurrent lock) and the updated architecture section.
+- **Escalated / not fixed in code:** latest-cycle **F-01** remains a supply-chain trust decision for piped installs. The installer supports size checks, marker checks, and optional `SLEEP_AFTER_CLAUDE_INSTALLER_SHA256`; without a user-supplied SHA pin, default `curl | bash` still trusts the HTTPS raw GitHub response.
+- **Remediation (merged to `main` as PR #4, squash commit `f5785c6`):**
+  - **F-02** — smart-mode idle completion now falls through cleanly to the release-caffeinate + sleep path instead of being revalidated as a PID watch.
+  - **F-03** — hook install fails closed on invalid `~/.claude/settings.json` and preserves the existing file.
+  - **F-04** — hook uninstall fails closed on invalid settings JSON, and hook readiness checks require `jq` rather than marker text alone.
+  - **F-05** — dry-run mode no longer auto-starts/releases `caffeinate` or calls `pmset sleepnow`, including `--sleep-now --dry-run`.
+  - **F-07** — watch locking and smart-mode flow prevent concurrent runs from racing on shared sleep side effects.
+- **Tests:** regression coverage was added or expanded in `tests/smart-watch-runtime.bats`, `tests/hooks.bats`, `tests/default-mode.bats`, and `tests/auto-caffeinate.bats`. Totals are retrievable via `bats tests/ --count`.
+- **Terminal UI polish (merged to `main` as PR #5, squash commit `386c5a8`):** help and log-summary rendering go through optional `glow`; confirmations fail closed when non-interactive; terminal UI behavior is covered by `tests/terminal-ui.bats`.
+- **Docs:** CLAUDE.md + README.md reflect the post-remediation state, including hooks, self-update, power gate, concurrent lock, terminal UI fallbacks, and the current GitHub Actions pipeline.
 
 ### 2026-04-19 (initial audit)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ This wires `.pre-commit-config.yaml` into `.git/hooks/pre-commit`, so every comm
 - `shfmt -i 2 -ci` formatting.
 - `shellcheck -S warning` — intentional suppressions must be inline with a reason (e.g., `# shellcheck disable=SC2207 # word-splitting desired for pgrep output`).
 - All user-facing output goes through the `print_*` helpers; TUI prompts go through `ui_*` helpers.
+- Markdown help/log output goes through `ui_markdown`; `gum` and `glow` must remain optional polish layers with plain fallbacks.
+- Comments use concise Bash `#` comments near the function or block they explain. Document contracts, side effects, and safety constraints; avoid comments that restate simple code. See `CLAUDE.md` for the full commenting standard.
 - Section banners (`# ── Section ──`) for navigation in long scripts.
 - No tabs.
 

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -94,7 +94,7 @@ Create one ruleset targeting `main` with:
 
 ## 3. Should be reviewed by a human before / shortly after publishing
 
-- [ ] **README license claim.** `README.md` Section 18 currently says *"No license file is currently present… 'All rights reserved' by default."* After this cycle, a `LICENSE` file does exist (MIT). The legal LICENSE file supersedes the README note, but the README wording is now stale. Updating README is explicitly out of scope for this hardening pass per the task brief; recommend a one-line fix in a follow-up commit. *(Suggested replacement: "This project is released under the MIT License — see `LICENSE` for the full text.")*
+- [ ] **README license claim.** `README.md` now points at the MIT `LICENSE` file and the license badge reflects MIT. Before publishing, confirm that MIT is still the intended license.
 - [ ] **Confirm the author name and year** in `LICENSE` (currently: *Sameh Abdalla, 2026*). Change if this should be attributed differently (e.g., a future company/organization).
 - [ ] **Confirm the `sambatia` GitHub username / org** in raw URLs across `sleep-after-claude` and `install-sleep-after-claude.sh`. If the repo ever moves under a different org, the installer and self-update URL defaults must be updated (users can always override via `SLEEP_AFTER_CLAUDE_INSTALLER_URL` / `SLEEP_AFTER_CLAUDE_UPDATE_URL`, but the defaults should be correct).
 - [ ] **Consider tagging a first release.** Once `main` is clean and CI is green, cut `v0.1.0`. Recommended: attach the SHA-256 of `install-sleep-after-claude.sh` at that tag to the release notes so security-conscious users can pin via `SLEEP_AFTER_CLAUDE_INSTALLER_SHA256` against a known-good published value.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![macOS](https://img.shields.io/badge/platform-macOS-silver)
 ![Shell](https://img.shields.io/badge/made%20with-Bash-1f425f.svg)
 ![Tests](https://img.shields.io/badge/tests-bats--core-brightgreen)
-![License](https://img.shields.io/badge/license-Unlicensed-lightgrey)
+![License](https://img.shields.io/badge/license-MIT-blue)
 ![Last commit](https://img.shields.io/github/last-commit/sambatia/sleep-after-claude)
 ![Open issues](https://img.shields.io/github/issues/sambatia/sleep-after-claude)
 
@@ -70,7 +70,7 @@ AI coding assistants like **Claude Code** are becoming the workhorse of serious 
 | 🛠️ **Zero config, one-liner install** | Non-technical users, ops teams, first-timers | Copy one `curl` command → working tool in ~5 seconds |
 | 📋 **Full audit log of what happened** | Debuggers, paranoid users, ops teams | Every event (started watching, Claude finished, sleep attempted) written to a log file you can read the next morning |
 | 🔍 **Machine-readable JSON output** | Automation, CI, power users | Feed the preflight verdict into scripts, dashboards, or other tools |
-| 🔒 **Security-hardened installer** | Anyone pasting `curl | bash` into their shell | Size checks, marker checks, optional SHA-256 pinning — the install can't silently ship the wrong binary |
+| 🔒 **Security-hardened installer** | Anyone pasting `curl | bash` into their shell | Size checks, marker checks, and optional SHA-256 pinning; users who need stronger provenance can pin both URL and hash |
 
 ---
 
@@ -205,37 +205,47 @@ flowchart TB
   INST -->|writes| SAC
 ```
 
-Everything happens locally on your Mac. Nothing phones home. No network traffic after install. The only external dependency is macOS itself — specifically the `pmset`, `pgrep`, `ps`, `caffeinate`, and `osascript` binaries that Apple ships with every machine.
+Everything important happens locally on your Mac. goodnight has no telemetry, analytics, or server-side component. Network access is limited to installation, optional one-time `jq` download, and the once-per-24h self-update check unless you disable it with `--skip-update-check` / `SAC_SKIP_UPDATE_CHECK=1`.
 
 ---
 
-## 📸 Section 9: Screenshots & Visual Tour
+## 📸 Section 9: Terminal Tour
 
-> **Note:** goodnight is a command-line tool. The "screenshots" below show terminal output rather than graphical UI. If you'd like real images, they can be added under a `screenshots/` folder — placeholders are noted.
+> **Note:** goodnight is a command-line tool. The current repository does not track static screenshot images; the commands below are the source of truth for the live terminal UI.
 
 ### 🖼️ The preflight audit
 
-![Preflight audit output](screenshots/preflight.png)
+Run:
 
-This is what you see when you run `goodnight --preflight`. It shows the target Claude process, which system daemons are holding sleep assertions (most are benign), and a final verdict at the bottom. If you see a green checkmark next to "No active sleep blockers detected", you can safely walk away.
+```bash
+goodnight --preflight
+```
 
-### 🖼️ The watch loop (waiting for Claude)
+The preflight view shows the target Claude process, any detected sleep assertions, power state, active user sessions, and a final verdict. If the scan fails, the verdict is "sleep-blocker scan unavailable" rather than a false "clear".
 
-![Watch loop spinner](screenshots/watching.png)
+### 🖼️ The watch loop
 
-After the preflight clears, you'll see a spinner with an elapsed-time counter. This updates 10 times per second and uses essentially zero CPU (thanks to a FIFO-based sleep trick). You can just close the laptop — the spinner keeps running in the background.
+Run:
 
-### 🖼️ The moment Claude finishes
+```bash
+goodnight
+```
 
-![Completion output](screenshots/finished.png)
+After the preflight gate clears, goodnight either watches Claude Code hook busy markers (`--smart`) or a concrete Claude PID (`--watch-pid`). Interactive terminals show a spinner; non-interactive output degrades to periodic plain status lines.
 
-As soon as Claude exits, you see a green checkmark with the total elapsed time. Any remaining `caffeinate` processes are released, and the Mac begins its sleep countdown (default 1 second). A completion sound plays if `--no-sound` isn't set.
+### 🖼️ The completion path
 
-### 🖼️ The JSON preflight (for power users)
+When the watched work finishes, goodnight releases the captured `caffeinate` processes, respects `--dry-run` / `--caffeinate-only`, waits the configured `--delay`, and calls `pmset sleepnow` with an AppleScript sleep fallback.
 
-![JSON preflight output](screenshots/json.png)
+### 🖼️ The JSON preflight
 
-Passing `--json` emits a machine-readable preflight report. The `scan_ok`, `can_sleep`, `blockers[]`, and `power.*` fields are stable and meant for scripts — you can feed this directly into other automation.
+Run:
+
+```bash
+goodnight --json --preflight
+```
+
+Passing `--json` emits a machine-readable preflight report. The `scan_ok`, `can_sleep`, `blockers[]`, and `power.*` fields are stable and meant for scripts — consumers must treat `can_sleep: null` as "unknown", not "safe".
 
 ---
 
@@ -312,16 +322,16 @@ Passing `--json` emits a machine-readable preflight report. The `scan_ok`, `can_
 
 #### 🧪 Quality
 
-- [x] **Full bats regression test suite** — one file per risk area, covering every finding from both audit cycles. Live count via `bats tests/ --count`.
+- [x] **Full bats regression test suite** — one file per risk area, covering every remediated finding from the audit cycles. Live count via `bats tests/ --count`.
 - [x] **Parity guard** — script that enforces the installer and standalone script match byte-for-byte.
 - [x] **Pre-commit framework integration** — `.pre-commit-config.yaml` runs parity + shellcheck + shfmt + hygiene on every commit.
+- [x] **GitHub Actions CI** — macOS runner enforces syntax, shellcheck, shfmt, parity, and bats on PRs and pushes to `main`.
 
 #### 🗺️ Planned
 
 - [ ] **Uninstall command** — one-shot removal of the binary, alias, and logs.
 - [ ] **Sub-hour timeout units** — accept `--timeout 30m` instead of hours-only.
 - [ ] **Caffeinate ownership check** — only kill `caffeinate` processes parented by Claude Code.
-- [ ] **GitHub Actions CI** — run the bats suite on a macOS runner at PR time.
 - [ ] **Immutable pinned release URL** — tagged GitHub Releases with baked-in SHA-256.
 
 ---
@@ -337,7 +347,7 @@ You need **macOS** — any modern version works (tested on macOS 26.x / Darwin 2
 | macOS | Any recent version | `sw_vers -productVersion` | Any Mac |
 | Bash or zsh | Any shipped version | `bash --version` | Pre-installed on macOS |
 | `curl` | Any | `curl --version` | Pre-installed on macOS |
-| Claude Code | Optional, but the whole point | `claude --version` | [claude.com/code](https://claude.com/code) |
+| Claude Code | Optional, but the whole point | `claude --version` | [claude.com/product/claude-code](https://claude.com/product/claude-code) |
 
 You do **not** need Node, Python, Homebrew, or anything else.
 
@@ -378,7 +388,7 @@ goodnight needs zero configuration for normal use. These are optional knobs:
 
 | Variable | Required? | Description | Example Value |
 |---|---|---|---|
-| `SLEEP_AFTER_CLAUDE_INSTALLER_URL` | No | Override the installer source URL (useful for pinning to a commit SHA) | `https://raw.githubusercontent.com/sambatia/sleep-after-claude/abc123.../install-sleep-after-claude.sh` |
+| `SLEEP_AFTER_CLAUDE_INSTALLER_URL` | No | Override the installer source URL (useful for pinning to a commit SHA) | `https://raw.githubusercontent.com/sambatia/sleep-after-claude/<commit-sha>/install-sleep-after-claude.sh` |
 | `SLEEP_AFTER_CLAUDE_INSTALLER_SHA256` | No | Require the downloaded installer to match a specific SHA-256 | `a41a6cfe20b6d4929cff4a5db00ad0c6...` |
 | `SLEEP_AFTER_CLAUDE_UPDATE_URL` | No | Override the self-update source URL (same format as installer URL) | main-branch raw URL |
 | `SAC_JQ_SHA256` | No | Override the expected SHA-256 for the auto-installed `jq` binary (for legitimate jq re-releases) | 64-hex hash |
@@ -702,7 +712,7 @@ A line starting with `ok` passed; `not ok` failed (with an error trace). The num
 | Environment | Notes |
 |---|---|
 | **Local dev** | Run against your own Mac. Use `HOME=/tmp/sandbox` to test installer behavior in isolation. |
-| **CI** | Bats tests currently require manual invocation. A macOS GitHub Actions runner is planned (see Roadmap). |
+| **CI** | GitHub Actions runs syntax, shellcheck, shfmt, parity, and bats on macOS for PRs and pushes to `main`. |
 | **Production (end-user Macs)** | Users get the tool via `curl | bash`. The GitHub raw URL is the production "server". |
 
 ---
@@ -744,7 +754,7 @@ A line starting with `ok` passed; `not ok` failed (with an error trace). The num
 
 ### Phase 4 — Release hygiene & reach (Current focus)
 
-- [ ] GitHub Actions CI running bats on macOS runners
+- [x] GitHub Actions CI running bats on macOS runners
 - [ ] Tagged GitHub Releases with immutable pinned URLs + baked-in SHA-256
 - [ ] Uninstall command (`goodnight --uninstall`)
 - [ ] Sub-hour timeout units (`--timeout 30m`)
@@ -818,7 +828,7 @@ This project is released under the **MIT License** — see [`LICENSE`](./LICENSE
 - **Apple** — for `pmset`, `caffeinate`, `pgrep`, and the rest of the macOS toolchain this project is built on.
 - **[bats-core](https://github.com/bats-core/bats-core)** — the bash testing framework that makes this project's regression suite possible.
 - **[Anthropic](https://www.anthropic.com/)** — for Claude Code, without which there'd be no "wait for Claude to finish" problem to solve.
-- **Claude Opus 4.7** — which ran the audit → remediation → test → docs cycle that hardened this project into its current shape.
+- **Claude Code** — which assisted the audit → remediation → test → docs cycle that hardened this project into its current shape.
 
 Built with late-night frustration and way too much respect for battery life.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,7 @@ If you are particularly security-conscious:
 
 - **Pin the installer URL to a specific commit SHA** via `SLEEP_AFTER_CLAUDE_INSTALLER_URL=https://raw.githubusercontent.com/sambatia/sleep-after-claude/<sha>/install-sleep-after-claude.sh`.
 - **Pin the installer SHA-256** via `SLEEP_AFTER_CLAUDE_INSTALLER_SHA256=<hex>`. The installer refuses to proceed if the download doesn't match.
+- Treat the default `curl | bash` path as HTTPS transport trust plus shape validation. The SHA pin is what turns installer-body substitution into a hard failure.
 - **Opt out of automatic `jq` install** by pre-installing `jq` yourself (`brew install jq`); the installer detects existing `jq` and skips the download.
 - **Opt out of Claude Code hook installation** via `SAC_SKIP_HOOK_INSTALL=1`.
 - **Disable the self-update check** via `--skip-update-check` or `SAC_SKIP_UPDATE_CHECK=1`.

--- a/install-sleep-after-claude.sh
+++ b/install-sleep-after-claude.sh
@@ -478,10 +478,11 @@ __SCRIPT_START__
 #!/usr/bin/env bash
 # ─────────────────────────────────────────────────────────────
 #  sleep-after-claude
-#  Watches a Claude Code process and sleeps the Mac when done.
+#  Watches Claude Code work and sleeps the Mac when it is done.
 #
-#  Includes a pre-flight scan of sleep-preventing processes and
-#  power assertions so you know whether sleep will actually happen.
+#  Supports hook-based smart idle detection, PID-exit watching,
+#  pre-flight sleep-blocker scans, optional terminal UI polish, and
+#  an auditable sleep attempt path.
 #
 #  Usage: sleep-after-claude [options]
 # ─────────────────────────────────────────────────────────────
@@ -630,6 +631,8 @@ have_glow() {
   command -v glow >/dev/null 2>&1
 }
 
+# Render markdown to the terminal when glow is available; otherwise
+# pass the plain markdown through unchanged for scripts and CI logs.
 ui_markdown() {
   if have_glow; then
     glow -
@@ -795,6 +798,8 @@ ui_spin() {
   "$@"
 }
 
+# Render the public CLI help from one markdown block so the styled and
+# plain fallbacks stay byte-for-byte consistent.
 usage() {
   ui_markdown <<'HELP'
 # sleep-after-claude
@@ -2027,9 +2032,9 @@ uninstall_claude_hooks() {
   print_ok "Removed goodnight hooks from ${BOLD}$CLAUDE_SETTINGS_FILE${RESET}"
 }
 
-# Count Claude sessions currently marked busy. Stale markers (file
-# mtime older than 2h) are treated as dead and deleted. Returns the
-# count on stdout.
+# Count Claude sessions currently marked busy. Stale markers older
+# than SMART_STALE_MARKER_MINS are treated as dead and deleted.
+# Returns the count on stdout.
 count_busy_sessions() {
   [[ -d "$BUSY_DIR" ]] || {
     echo 0
@@ -2048,19 +2053,17 @@ count_busy_sessions() {
 }
 
 # Smart-watch loop. Polls the busy directory every 2 seconds. Sleep
-# fires only when ALL of:
+# fires only when BOTH enforced hook-state conditions hold:
 #   (a) at least one busy marker has been observed since watch start
 #       (prevents premature-sleep on cold start — F-01), AND
 #   (b) the busy directory has been empty continuously for
-#       SMART_IDLE_SECONDS, AND
-#   (c) no live Claude process is present (belt-and-suspenders guard
-#       against forgotten Claude sessions that never fired a hook
-#       — e.g., hooks not loaded because the session pre-dates
-#       --install-hooks).
+#       SMART_IDLE_SECONDS.
 #
 # If no busy marker ever appears but there IS a live Claude process,
 # the loop stays in "cold" state and warns the user via the spinner
-# text that hooks may not be loaded in the running session.
+# text that hooks may not be loaded in the running session. There is
+# no separate live-process absence guard in smart mode; hooks are the
+# contract for idle detection.
 smart_watch_loop() {
   local idle_start=0 now busy seen_busy=false
   local frames=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")

--- a/sleep-after-claude
+++ b/sleep-after-claude
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # ─────────────────────────────────────────────────────────────
 #  sleep-after-claude
-#  Watches a Claude Code process and sleeps the Mac when done.
+#  Watches Claude Code work and sleeps the Mac when it is done.
 #
-#  Includes a pre-flight scan of sleep-preventing processes and
-#  power assertions so you know whether sleep will actually happen.
+#  Supports hook-based smart idle detection, PID-exit watching,
+#  pre-flight sleep-blocker scans, optional terminal UI polish, and
+#  an auditable sleep attempt path.
 #
 #  Usage: sleep-after-claude [options]
 # ─────────────────────────────────────────────────────────────
@@ -153,6 +154,8 @@ have_glow() {
   command -v glow >/dev/null 2>&1
 }
 
+# Render markdown to the terminal when glow is available; otherwise
+# pass the plain markdown through unchanged for scripts and CI logs.
 ui_markdown() {
   if have_glow; then
     glow -
@@ -318,6 +321,8 @@ ui_spin() {
   "$@"
 }
 
+# Render the public CLI help from one markdown block so the styled and
+# plain fallbacks stay byte-for-byte consistent.
 usage() {
   ui_markdown <<'HELP'
 # sleep-after-claude
@@ -1550,9 +1555,9 @@ uninstall_claude_hooks() {
   print_ok "Removed goodnight hooks from ${BOLD}$CLAUDE_SETTINGS_FILE${RESET}"
 }
 
-# Count Claude sessions currently marked busy. Stale markers (file
-# mtime older than 2h) are treated as dead and deleted. Returns the
-# count on stdout.
+# Count Claude sessions currently marked busy. Stale markers older
+# than SMART_STALE_MARKER_MINS are treated as dead and deleted.
+# Returns the count on stdout.
 count_busy_sessions() {
   [[ -d "$BUSY_DIR" ]] || {
     echo 0
@@ -1571,19 +1576,17 @@ count_busy_sessions() {
 }
 
 # Smart-watch loop. Polls the busy directory every 2 seconds. Sleep
-# fires only when ALL of:
+# fires only when BOTH enforced hook-state conditions hold:
 #   (a) at least one busy marker has been observed since watch start
 #       (prevents premature-sleep on cold start — F-01), AND
 #   (b) the busy directory has been empty continuously for
-#       SMART_IDLE_SECONDS, AND
-#   (c) no live Claude process is present (belt-and-suspenders guard
-#       against forgotten Claude sessions that never fired a hook
-#       — e.g., hooks not loaded because the session pre-dates
-#       --install-hooks).
+#       SMART_IDLE_SECONDS.
 #
 # If no busy marker ever appears but there IS a live Claude process,
 # the loop stays in "cold" state and warns the user via the spinner
-# text that hooks may not be loaded in the running session.
+# text that hooks may not be loaded in the running session. There is
+# no separate live-process absence guard in smart mode; hooks are the
+# contract for idle detection.
 smart_watch_loop() {
   local idle_start=0 now busy seen_busy=false
   local frames=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")


### PR DESCRIPTION
## What this changes

Synchronizes the repository knowledge graph and production comments after the audit/remediation/test-expansion cycle and terminal UX polish.

- Updates README, CLAUDE.md, CONTRIBUTING, SECURITY, release checklist, and CI comments to match current implementation state.
- Clarifies the remaining installer trust boundary for default `curl | bash` installs versus SHA-pinned installs.
- Corrects stale Bash comments in `sleep-after-claude` and the installer embedded payload without changing executable code.

## Verification

- `bash -n sleep-after-claude install-sleep-after-claude.sh scripts/check-parity.sh .githooks/pre-commit && bash scripts/check-parity.sh`
- `shellcheck -S warning sleep-after-claude install-sleep-after-claude.sh scripts/check-parity.sh .githooks/pre-commit tests/lib/common.bash`
- `shfmt -d -i 2 -ci sleep-after-claude install-sleep-after-claude.sh scripts/check-parity.sh .githooks/pre-commit tests/lib/common.bash`
- `git diff --name-only -- tests && git diff --check`
- `bats tests/`

## Notes

No test files were changed. Source changes are comment-only and mirrored into the embedded installer payload; parity check passes.